### PR TITLE
Simplify Types + Fix output

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { makeLayout, makeNode } from '../src/index'
+import { makeLayout, LayoutNode } from '../src/index'
 
-const chartNode = makeNode('chart-wrapper', {
+const chartNode: LayoutNode<'chart-wrapper' | 'center'> = {
+  id: 'chart-wrapper',
   width: 'auto',
   height: '100%',
   padding: [10, 20],
-  direction: 'row' as 'row',
+  direction: 'row',
   children: [{ id: 'center', width: '100%', height: '100%' }],
-})
+}
 
 const layout = makeLayout({
   id: 'root',

--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -1,6 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { makeLayout } from '../src/index'
+import { makeLayout, makeNode } from '../src/index'
+
+const chartNode = makeNode('chart-wrapper', {
+  width: 'auto',
+  height: '100%',
+  padding: [10, 20],
+  direction: 'row' as 'row',
+  children: [{ id: 'center', width: '100%', height: '100%' }],
+})
 
 const layout = makeLayout({
   id: 'root',
@@ -18,14 +26,7 @@ const layout = makeLayout({
       padding: 0,
       children: [
         { id: 'left', width: 100, height: '100%' },
-        {
-          id: 'center-wrapper',
-          width: 'auto',
-          height: '100%',
-          padding: [10, 20],
-          direction: 'row',
-          children: [{ id: 'center', width: '100%', height: '100%' }],
-        },
+        chartNode,
         { id: 'right', width: 100, height: '100%' },
       ],
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,8 @@ export type LayoutBlock = {
   height: number
   top: number
   left: number
-  right?: number
-  bottom?: number
+  right: number
+  bottom: number
 }
 
 type Iterate<T, Acc = {}> = T extends [infer Head, ...infer Tail]
@@ -102,8 +102,8 @@ function makeBlocks(nodes: LayoutNode[], rootBlock: LayoutNodeRoot): LayoutBlock
   // position the elements
   const rootTop = (rootBlock?.top ?? 0) + padding.top
   const rootLeft = (rootBlock?.left ?? 0) + padding.left
-  let lefts
-  let tops
+  let lefts: number[]
+  let tops: number[]
   if (rootBlock.direction === 'column') {
     lefts = widths.map(() => rootLeft)
     tops = heights.map((_h, i) => rootTop + _.sum(heights.slice(0, i)))
@@ -114,17 +114,20 @@ function makeBlocks(nodes: LayoutNode[], rootBlock: LayoutNodeRoot): LayoutBlock
     throw new Error(`A node with children must specify a direction`)
   }
   // create the blocks
-  const blocks = _.zip<LayoutNode | string | number>(nodes, ids, widths, heights, tops, lefts).map(
-    ([node, id, width, height, top, left]) =>
-      ({
-        id,
-        width,
-        height,
-        top,
-        left,
-        node,
-      } as LayoutBlock & { node: LayoutNode })
-  )
+  const blocks = _.times(nodes.length).map<LayoutBlock & { node: LayoutNode }>((i) => {
+    const id = ids[i]
+    const node = nodes[i]
+
+    const width = widths[i]
+    const height = heights[i]
+    const top = tops[i]
+    const left = lefts[i]
+    const bottom = top + height
+    const right = left + width
+
+    return { id, width, height, top, left, node, bottom, right }
+  })
+
   // append their children blocks
   const childrenBlocks = blocks.flatMap((b) =>
     b.node.children !== undefined ? makeBlocks(b.node.children, { ...b.node, ...b }) : []

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export type PaddingFormat =
   | number
   | [number, number]
   | [number, number, number, number]
-  | { top: number; right: number; bottom: number; left: number }
+  | { top?: number; right?: number; bottom?: number; left?: number }
 
 function buildPadding(padding: PaddingFormat) {
   if (typeof padding === 'number') {
@@ -26,6 +26,8 @@ function buildPadding(padding: PaddingFormat) {
   } else if (Array.isArray(padding)) {
     const [top = 0, right = 0, bottom = 0, left = 0] = padding
     return { top, right, bottom, left }
+  } else if (_.isObject(padding)) {
+    return { top: 0, left: 0, right: 0, bottom: 0, ...padding }
   } else {
     throw new Error(`Unrecognized margin format: ${JSON.stringify(padding)}`)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,14 +61,6 @@ export type LayoutBlock = {
   bottom: number
 }
 
-export const makeNode = <Id extends string>(
-  id: Id,
-  config: Omit<LayoutNode<Id>, 'id'>
-): LayoutNode<Id> => ({
-  id,
-  ...config,
-})
-
 type ComputedLayout<Id extends string> = { [k in Id]: LayoutBlock }
 
 function makeBlocks<Id extends string>(


### PR DESCRIPTION
- Types are now simpler: `ComputedLayout` + `Iterate`
- add some useful types export
- fixed output: now `LayoutBlock` has `right` and `bottom`
- support padding object type